### PR TITLE
docs: add Staker exercise prerequisites

### DIFF
--- a/part2/README.md
+++ b/part2/README.md
@@ -14,3 +14,11 @@ The slides for this part can be found [here](./Echidna_Part_2_Slides.pdf).
 ## Video Presentation
 
 The video presentation for this part can be found on [YouTube](TODO).
+
+## Prerequisites (Staker)
+
+Because Staker is a Hardhat project, before being able to fuzz it with Echidna, you have to install its dependencies.
+
+Make sure you have npm installed. 
+
+Once you are in the Staker directory run `npm install`. 


### PR DESCRIPTION
I was unable to fuzz the Staker contract with the ` echidna-test . --contract EchidnaTemplate --config config.yaml`. Running this command returns the following errors: 
- `echidna-test: Couldn't compile given file`
- `ERROR:CryticCompile:Error HH12: Trying to use a non-local installation of Hardhat, which is not supported.`
- `FileNotFoundError: [Errno 2] No such file or directory: 'artifacts/build-info'`

Installing the node modules with `npm install` solved the issue.

I know this might be obvious to some people, but it took me a while to figure that one out.