### PR TITLE
Add `testInitialLiquidity` to part 3 tests

### DIFF
--- a/part3/contracts/crytic/EchidnaTest.sol
+++ b/part3/contracts/crytic/EchidnaTest.sol
@@ -35,4 +35,24 @@ contract EchidnaTest is Setup {
 
     }
 
+    function testInitialLiquidity(uint amount1, uint amount2) public {
+        // Precondition: user attempts to create a new pair without supplying minimum liquidity
+        require(pair.totalSupply() == 0);
+        amount1 = _between(amount1, 1, 1000);
+        amount2 = _between(amount2, 1, 1000);
+
+        if(!completed) {
+            _mintTokens(amount1, amount2);
+        }
+        (bool success1, ) = user.proxy(address(testToken1), abi.encodeWithSelector(testToken1.transfer.selector, address(pair), amount1));
+        (bool success2, ) = user.proxy(address(testToken2), abi.encodeWithSelector(testToken2.transfer.selector, address(pair), amount2));
+        require(success1 && success2);
+
+        // Action: attempt to get LP tokens
+        (bool success3, ) = user.proxy(address(pair), abi.encodeWithSelector(bytes4(keccak256("mint(address)")), address(user)));
+
+        // Postconditions:
+        assert(!success3); // Since minimum liquidity was not provided, mint should revert with 'UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED'
+        assert(pair.balanceOf(address(user)) == 0); // User should not be awarded any LP tokens
+    }
 }


### PR DESCRIPTION
Thank you Justin for the stream today, very insightful.

The purpose of this test is to check that this logic in the `mint` function of `UniswapV2Pair` is working as expected:

```solidity
if (_totalSupply == 0) {
    liquidity = Math.sqrt(amount0.mul(amount1)).sub(MINIMUM_LIQUIDITY);
    _mint(address(0), MINIMUM_LIQUIDITY); // permanently lock the first MINIMUM_LIQUIDITY tokens
}

// ...

require(liquidity > 0, 'UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED');
```

The coverage report says the new `assert`s are getting hit, so I think the test is working.

I'm wondering if this is a good invariant to test though? During the stream I know you set the minimum amounts for `testProvideLiquidity` to `1000`. My reasoning for adding this test is that because `Math` is a custom library, we'd want to confirm the `sqrt` logic works. Or is it safe to assume this library does what it's supposed to?

Appreciate any feedback and thank you all again for the great series!