### PR TITLE
Part 3 and 4 Update EchidnaTest.sol, Setup.sol, and 2 more files...

### DIFF
--- a/part3/contracts/crytic/EchidnaTest.sol
+++ b/part3/contracts/crytic/EchidnaTest.sol
@@ -12,22 +12,29 @@ contract EchidnaTest is Setup {
         if(!completed) {
             _init(amount1, amount2);
         }
-        uint lpTokenBalanceBefore = pair.balanceOf(address(user));
-        (uint reserve0Before, uint reserve1Before,) = pair.getReserves();
+        ( ,bytes memory balanceDataBefore) = user.proxy(testPair, abi.encodeWithSignature("balanceOf(address)", address(user))); //pair.balanceOf(address(user));
+        uint lpTokenBalanceBefore = abi.decode(balanceDataBefore, (uint));
+
+        (, bytes memory reserveDataBefore) = user.proxy(testPair, abi.encodeWithSignature("getReserves()")); //pair.getReserves();
+        (uint reserve0Before,uint reserve1Before) = abi.decode(reserveDataBefore, (uint,uint));
         uint kBefore = reserve0Before * reserve1Before;
 
-        (bool success1,) = user.proxy(address(testToken1),abi.encodeWithSelector(testToken1.transfer.selector, address(pair),amount1));
-        (bool success2,) = user.proxy(address(testToken2),abi.encodeWithSelector(testToken2.transfer.selector, address(pair),amount2));
+        (bool success1,) = user.proxy(address(testToken1),abi.encodeWithSelector(testToken1.transfer.selector, testPair,amount1));
+        (bool success2,) = user.proxy(address(testToken2),abi.encodeWithSelector(testToken2.transfer.selector, testPair,amount2));
         require(success1 && success2);
 
         //Action:
-        (bool success3,) = user.proxy(address(pair),abi.encodeWithSelector(bytes4(keccak256("mint(address)")), address(user)));
+        (bool success3,) = user.proxy(testPair,abi.encodeWithSelector(bytes4(keccak256("mint(address)")), address(user)));
         
         //Postconditions:
         if(success3) {
-            uint lpTokenBalanceAfter = pair.balanceOf(address(user));
-            (uint reserve0After, uint reserve1After,) = pair.getReserves();
+            ( ,bytes memory balanceDataAfter) = user.proxy(testPair, abi.encodeWithSignature("balanceOf(address)", address(user))); //pair.balanceOf(address(user));
+            uint lpTokenBalanceAfter = abi.decode(balanceDataAfter, (uint));
+           
+            (, bytes memory reserveDataAfter) = user.proxy(testPair, abi.encodeWithSignature("getReserves()")); //pair.getReserves();
+            (uint reserve0After,uint reserve1After) = abi.decode(reserveDataAfter, (uint,uint));
             uint kAfter = reserve0After * reserve1After;
+            
             assert(lpTokenBalanceBefore < lpTokenBalanceAfter);
             assert(kBefore < kAfter);
 
@@ -41,10 +48,15 @@ contract EchidnaTest is Setup {
         }
         
         //Preconditions
-        pair.sync(); // we matched the balances with reserves
-        require(pair.balanceOf(address(user)) > 0); //there is liquidity for the swap
+        user.proxy(testPair, abi.encodeWithSignature("sync()")); //pair.sync(); // we matched the balances with reserves
+
+        (, bytes memory pairBalanceData) = user.proxy(testPair, abi.encodeWithSignature("balanceOf(address)", address(user)));
+        uint pairBalance = abi.decode(pairBalanceData, (uint));
+        require(pairBalance > 0); //there is liquidity for the swap
+
         //Call:
-        (bool success1,) = user.proxy(address(pair), abi.encodeWithSelector(pair.swap.selector, amount1,amount2,address(user),""));
+        (bool success1,) = user.proxy(testPair,abi.encodeWithSignature("swap(uint256,uint256,address,bytes)", amount1,amount2,address(user),""));
+        //(bool success1,) = user.proxy(testPair, abi.encodeWithSelector(pair.swap.selector, amount1,amount2,address(user),""));
 
         //Postcondition:
         assert(!success1); //call should never succeed

--- a/part3/contracts/crytic/Setup.sol
+++ b/part3/contracts/crytic/Setup.sol
@@ -12,7 +12,8 @@ contract Users {
 
 contract Setup {
     UniswapV2Factory factory;
-    UniswapV2Pair pair;
+    //UniswapV2Pair pair; //Factory will initialize the pair
+    address testPair;
     UniswapV2ERC20 testToken1;
     UniswapV2ERC20 testToken2;
     Users user;
@@ -22,11 +23,11 @@ contract Setup {
         testToken1 = new UniswapV2ERC20();
         testToken2 = new UniswapV2ERC20();
         factory = new UniswapV2Factory(address(this));
-        address testPair = factory.createPair(address(testToken1), address(testToken2));
-        pair = UniswapV2Pair(testPair);
+        testPair = factory.createPair(address(testToken1), address(testToken2));
+        //pair = UniswapV2Pair(testPair); //Pair constructor does not take arguments, and pair is already initialized
         user = new Users();
-        user.proxy(address(testToken1),abi.encodeWithSelector(testToken1.approve.selector, address(pair),uint(-1)));
-        user.proxy(address(testToken2), abi.encodeWithSelector(testToken2.approve.selector,address(pair),uint(-1)));
+        user.proxy(address(testToken1),abi.encodeWithSelector(testToken1.approve.selector, testPair,uint(-1)));
+        user.proxy(address(testToken2), abi.encodeWithSelector(testToken2.approve.selector,testPair,uint(-1)));
     }
 
     function _init(uint amount1, uint amount2) internal {

--- a/part4/contracts/crytic/EchidnaUniV2Tester.sol
+++ b/part4/contracts/crytic/EchidnaUniV2Tester.sol
@@ -12,8 +12,10 @@ contract EchidnaUniV2Tester is Setup {
             _init(amount1,amount2);
         }
         
-        uint pairBalanceBefore = testPair.balanceOf(address(user));
-        
+        //uint pairBalanceBefore = testPair.balanceOf(address(user));
+        ( ,bytes memory balanceDataBefore) = user.proxy(pair, abi.encodeWithSignature("balanceOf(address)", address(user)));  //pair.balanceOf(address(user));
+        uint pairBalanceBefore = abi.decode(balanceDataBefore, (uint));
+
         (uint reserve1Before, uint reserve2Before) = UniswapV2Library.getReserves(address(factory), address(testToken1), address(testToken2));
         
         uint kBefore = reserve1Before * reserve2Before;
@@ -26,8 +28,12 @@ contract EchidnaUniV2Tester is Setup {
        
         if (success) {
             (uint reserve1After, uint reserve2After) = UniswapV2Library.getReserves(address(factory), address(testToken1), address(testToken2));
-            uint pairBalanceAfter = testPair.balanceOf(address(user));
+
+            //uint pairBalanceAfter = testPair.balanceOf(address(user));
+            (, bytes memory balanceDataAfter) = user.proxy(pair, abi.encodeWithSignature("balanceOf(address)", address(user)));  //pair.balanceOf(address(user));
+            uint pairBalanceAfter= abi.decode(balanceDataAfter, (uint));
             uint kAfter = reserve1After*reserve2After;
+
             assert(kBefore < kAfter);
             assert(pairBalanceBefore < pairBalanceAfter);
         }
@@ -75,7 +81,9 @@ contract EchidnaUniV2Tester is Setup {
     function testRemoveLiquidityInvariants(uint lpAmount) public {
         //PRECONDITIONS:
 
-        uint pairBalanceBefore = testPair.balanceOf(address(user));
+        //uint pairBalanceBefore = testPair.balanceOf(address(user));
+        ( ,bytes memory balanceDataBefore) = user.proxy(pair, abi.encodeWithSignature("balanceOf(address)", address(user)));  //pair.balanceOf(address(user));
+        uint pairBalanceBefore = abi.decode(balanceDataBefore, (uint));
         //user needs some LP tokens to burn
         require(pairBalanceBefore > 0);
         lpAmount = _between(lpAmount, 1, pairBalanceBefore);
@@ -83,7 +91,8 @@ contract EchidnaUniV2Tester is Setup {
         (uint reserve1Before, uint reserve2Before) = UniswapV2Library.getReserves(address(factory), address(testToken1), address(testToken2));
         //need to provide more than min liquidity
         uint kBefore = reserve1Before * reserve2Before;
-       (bool success1,) = user.proxy(address(testPair),abi.encodeWithSelector(testPair.approve.selector,address(router),uint(-1)));
+        //(bool success1,) = user.proxy(testPair,abi.encodeWithSelector(testPair.approve.selector,address(router),uint(-1)));
+        (bool success1,) = user.proxy(address(pair), abi.encodeWithSignature("approve(address,uint256)", address(router),uint(-1)));
         require(success1);
         //CALL:
 
@@ -94,7 +103,11 @@ contract EchidnaUniV2Tester is Setup {
         
         if (success) {
             (uint reserve1After, uint reserve2After) = UniswapV2Library.getReserves(address(factory), address(testToken1), address(testToken2));
-            uint pairBalanceAfter = testPair.balanceOf(address(user));
+            
+            //uint pairBalanceAfter = testPair.balanceOf(address(user));
+            (, bytes memory balanceDataAfter) = user.proxy(pair, abi.encodeWithSignature("balanceOf(address)", address(user)));  //pair.balanceOf(address(user));
+            uint pairBalanceAfter= abi.decode(balanceDataAfter, (uint));
+
             uint kAfter = reserve1After*reserve2After;
             assert(kBefore > kAfter);
             assert(pairBalanceBefore > pairBalanceAfter);

--- a/part4/contracts/crytic/Setup.sol
+++ b/part4/contracts/crytic/Setup.sol
@@ -18,7 +18,8 @@ contract Users {
 contract Setup {
     UniswapV2ERC20 testToken1; 
     UniswapV2ERC20 testToken2;
-    UniswapV2Pair testPair;
+    //UniswapV2Pair testPair;  //factory initializes pair
+    address pair;
     UniswapV2Factory factory;
     UniswapV2Router01 router;
     Users user;
@@ -29,8 +30,8 @@ contract Setup {
         testToken2 = new UniswapV2ERC20();
         factory = new UniswapV2Factory(address(this)); //this contract will be the fee setter
         router = new UniswapV2Router01(address(factory),address(0)); // we don't need to test WETH pairs for now
-        address pair = factory.createPair(address(testToken1), address(testToken2));
-        testPair = UniswapV2Pair(pair);
+        pair = factory.createPair(address(testToken1), address(testToken2));
+        //testPair = UniswapV2Pair(pair);  //pair constructor does not take arguments
         user = new Users();
         
 


### PR DESCRIPTION
In parts 3 and 4, UniswapV2Pair() does not take arguments, so the references to " pair.**** " were broken. I'm not sure how this worked on the live stream, but to get it to compile for me, I had to change the pair function calls to use abi.encodeWithSignature() using the pair address created by the factory in the initialization.  All references to the pair in parts 3 and 4 are updated, so the scripts should now compile out of the box. Since I'm fairly new to Solidity and Echidna, I'd love to get some feedback on this, especially if I missed something in the original implementation.