### PR TITLE
Fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 **/crytic-export/*
-**/node-modules/*
+**/node_modules/*
 **/corpus/*
 **/.DS_Store
 **/types/* 


### PR DESCRIPTION
Replaced hyphen with underscore in `node_modules` since it wasn't properly ignoring them