### PR TITLE
Sort test tokens in constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 **/crytic-export/*
-**/node-modules/*
+**/node_modules/*
 **/corpus/*
 **/.DS_Store
 **/types/* 

--- a/part3/contracts/crytic/Setup.sol
+++ b/part3/contracts/crytic/Setup.sol
@@ -11,33 +11,28 @@ contract Users {
 }
 
 contract Setup {
-    UniswapV2Factory factory;
-    UniswapV2Pair pair;
     UniswapV2ERC20 testToken1;
     UniswapV2ERC20 testToken2;
+    UniswapV2Factory factory;
+    UniswapV2Pair pair;
     Users user;
     bool completed;
-    
+
     constructor() public {
         testToken1 = new UniswapV2ERC20();
         testToken2 = new UniswapV2ERC20();
         factory = new UniswapV2Factory(address(this));
-        address testPair = factory.createPair(address(testToken1), address(testToken2));
-        pair = UniswapV2Pair(testPair);
+        pair = UniswapV2Pair(factory.createPair(address(testToken1), address(testToken2)));
         user = new Users();
-        user.proxy(address(testToken1),abi.encodeWithSelector(testToken1.approve.selector, address(pair),uint(-1)));
-        user.proxy(address(testToken2), abi.encodeWithSelector(testToken2.approve.selector,address(pair),uint(-1)));
     }
 
-    function _init(uint amount1, uint amount2) internal {
+    function _mintTokens(uint amount1, uint amount2) internal {
         testToken1.mint(address(user), amount1);
         testToken2.mint(address(user), amount2);
         completed = true;
     }
 
-    function _between(uint val, uint low, uint high) internal pure returns(uint) {
-        return low + (val % (high-low +1)); 
+    function _between(uint value, uint low, uint high) internal pure returns (uint) {
+        return (low + (value % (high - low + 1)));
     }
-
-
 }

--- a/part3/contracts/crytic/Setup.sol
+++ b/part3/contracts/crytic/Setup.sol
@@ -25,6 +25,7 @@ contract Setup {
         factory = new UniswapV2Factory(address(this));
         address testPair = factory.createPair(address(testToken1), address(testToken2));
         pair = UniswapV2Pair(testPair);
+        // Sort the test tokens we just created, for clarity when writing invariant tests later
         (address testTokenA, address testTokenB) = UniswapV2Library.sortTokens(address(testToken1), address(testToken2));
         testToken1 = UniswapV2ERC20(testTokenA);
         testToken2 = UniswapV2ERC20(testTokenB);

--- a/part3/contracts/crytic/Setup.sol
+++ b/part3/contracts/crytic/Setup.sol
@@ -11,28 +11,33 @@ contract Users {
 }
 
 contract Setup {
-    UniswapV2ERC20 testToken1;
-    UniswapV2ERC20 testToken2;
     UniswapV2Factory factory;
     UniswapV2Pair pair;
+    UniswapV2ERC20 testToken1;
+    UniswapV2ERC20 testToken2;
     Users user;
     bool completed;
-
+    
     constructor() public {
         testToken1 = new UniswapV2ERC20();
         testToken2 = new UniswapV2ERC20();
         factory = new UniswapV2Factory(address(this));
-        pair = UniswapV2Pair(factory.createPair(address(testToken1), address(testToken2)));
+        address testPair = factory.createPair(address(testToken1), address(testToken2));
+        pair = UniswapV2Pair(testPair);
         user = new Users();
+        user.proxy(address(testToken1),abi.encodeWithSelector(testToken1.approve.selector, address(pair),uint(-1)));
+        user.proxy(address(testToken2), abi.encodeWithSelector(testToken2.approve.selector,address(pair),uint(-1)));
     }
 
-    function _mintTokens(uint amount1, uint amount2) internal {
+    function _init(uint amount1, uint amount2) internal {
         testToken1.mint(address(user), amount1);
         testToken2.mint(address(user), amount2);
         completed = true;
     }
 
-    function _between(uint value, uint low, uint high) internal pure returns (uint) {
-        return (low + (value % (high - low + 1)));
+    function _between(uint val, uint low, uint high) internal pure returns(uint) {
+        return low + (val % (high-low +1)); 
     }
+
+
 }

--- a/part3/contracts/crytic/Setup.sol
+++ b/part3/contracts/crytic/Setup.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.6.0;
 import "../uni-v2/UniswapV2ERC20.sol";
 import "../uni-v2/UniswapV2Pair.sol";
 import "../uni-v2/UniswapV2Factory.sol";
+import "../libraries/UniswapV2Library.sol";
 
 contract Users {
     function proxy(address target, bytes memory data) public returns (bool success, bytes memory retData) {
@@ -24,6 +25,9 @@ contract Setup {
         factory = new UniswapV2Factory(address(this));
         address testPair = factory.createPair(address(testToken1), address(testToken2));
         pair = UniswapV2Pair(testPair);
+        (address testTokenA, address testTokenB) = UniswapV2Library.sortTokens(address(testToken1), address(testToken2));
+        testToken1 = UniswapV2ERC20(testTokenA);
+        testToken2 = UniswapV2ERC20(testTokenB);
         user = new Users();
         user.proxy(address(testToken1),abi.encodeWithSelector(testToken1.approve.selector, address(pair),uint(-1)));
         user.proxy(address(testToken2), abi.encodeWithSelector(testToken2.approve.selector,address(pair),uint(-1)));

--- a/part4/contracts/crytic/Setup.sol
+++ b/part4/contracts/crytic/Setup.sol
@@ -32,7 +32,10 @@ contract Setup {
         address pair = factory.createPair(address(testToken1), address(testToken2));
         testPair = UniswapV2Pair(pair);
         user = new Users();
-        
+        // Sort the test tokens we just created, for clarity when writing invariant tests later
+        (address testTokenA, address testTokenB) = UniswapV2Library.sortTokens(address(testToken1), address(testToken2));
+        testToken1 = UniswapV2ERC20(testTokenA);
+        testToken2 = UniswapV2ERC20(testTokenB);
 
     }
     


### PR DESCRIPTION
When writing my own invariants to test the `pair.swap` function, I realized I was running into problems because my `amount0` and `amount1` arguments did not correspond to the tokens I thought they did. i.e., `amount0` did not correspond to `testToken0` when using the argument for calculating the `amount0Out` parameter in the `swap` function, rather it should have been used for `amount1Out`. Using the `UniswapV2Library.sortTokens` function in my `Setup` contract's constructor resolved this issue, and should be useful for anyone else who wants to use the part 3 code as a starting point for writing their own invariants.