### PR TITLE
Extend coverage on uniswapPair mint()

### DIFF
--- a/part3/contracts/crytic/EchidnaTest.sol
+++ b/part3/contracts/crytic/EchidnaTest.sol
@@ -4,18 +4,22 @@ import "./Setup.sol";
 
 contract EchidnaTest is Setup {
     event logUints(uint unit1, uint unit2);
-    function testProvideLiquidity(uint amount1, uint amount2) public {
-        //Preconditions: 
-        amount1 = _between(amount1, 1000, uint(-1));
-        amount2 = _between(amount2, 1000, uint(-1));
 
-        if(!completed) {
-            _init(amount1, amount2);
+    
+    function mintLiquidity(uint amount1, uint amount2) public returns (bool,uint,uint)  {
+        //precondition
+        if(!notInitialLiquidityMint) {
+            amount1 = _between(amount1, 1000, uint(-1));
+            amount2 = _between(amount2, 1000, uint(-1));
+            notInitialLiquidityMint = true;
         }
+
+        _init(amount1, amount2);
+
         uint lpTokenBalanceBefore = pair.balanceOf(address(user));
         (uint reserve0Before, uint reserve1Before,) = pair.getReserves();
         uint kBefore = reserve0Before * reserve1Before;
-
+        
         (bool success1,) = user.proxy(address(testToken1),abi.encodeWithSelector(testToken1.transfer.selector, address(pair),amount1));
         (bool success2,) = user.proxy(address(testToken2),abi.encodeWithSelector(testToken2.transfer.selector, address(pair),amount2));
         require(success1 && success2);
@@ -23,8 +27,14 @@ contract EchidnaTest is Setup {
         //Action:
         (bool success3,) = user.proxy(address(pair),abi.encodeWithSelector(bytes4(keccak256("mint(address)")), address(user)));
         
+        return (success3, lpTokenBalanceBefore, kBefore);
+    }
+    //Allows to mint liquidity not just on initial scenario and extend coverage
+    function testProvideLiquidity(uint amount1, uint amount2) public {
+        //perform preconditions and action on mintLiquidity
+        (bool success, uint lpTokenBalanceBefore, uint kBefore) = mintLiquidity(amount1, amount2);
         //Postconditions:
-        if(success3) {
+        if(success) {
             uint lpTokenBalanceAfter = pair.balanceOf(address(user));
             (uint reserve0After, uint reserve1After,) = pair.getReserves();
             uint kAfter = reserve0After * reserve1After;
@@ -34,6 +44,7 @@ contract EchidnaTest is Setup {
         }
 
     }
+    
     function testSwap(uint amount1, uint amount2) public {
         
         if(!completed) {
@@ -48,8 +59,6 @@ contract EchidnaTest is Setup {
 
         //Postcondition:
         assert(!success1); //call should never succeed
-
-
-    
     }
+    
 }

--- a/part3/contracts/crytic/Setup.sol
+++ b/part3/contracts/crytic/Setup.sol
@@ -16,7 +16,7 @@ contract Setup {
     UniswapV2ERC20 testToken1;
     UniswapV2ERC20 testToken2;
     Users user;
-    bool completed;
+    bool notInitialLiquidityMint;
     
     constructor() public {
         testToken1 = new UniswapV2ERC20();
@@ -32,12 +32,9 @@ contract Setup {
     function _init(uint amount1, uint amount2) internal {
         testToken1.mint(address(user), amount1);
         testToken2.mint(address(user), amount2);
-        completed = true;
     }
 
     function _between(uint val, uint low, uint high) internal pure returns(uint) {
         return low + (val % (high-low +1)); 
     }
-
-
 }


### PR DESCRIPTION
I just finished part 3 of the echidna streaming series and I noticed that coverage didnt marked  * on liquidity mint after the intial scenario were totalSupply was cero. I modified our invariant test to extend this and have full coverage on UniswapPair `mint()` function.

![image](https://user-images.githubusercontent.com/71742691/215185930-e5eb33a1-556c-4e96-b68a-a71f0ce0ae65.png)

I moved the initial preconditions and action to a public function: `mintLiquidty()` that can be called previous to our target test `testProvideLiquidity()`. Additionaly, I modified the amount bounding to only account for the initial liquidity minting which is the only moment where we need to provide at least 1000 tokens.

![image](https://user-images.githubusercontent.com/71742691/215185758-f14712a3-0af5-4e7f-9cf2-ec60ca91f601.png)

Looking forward to get some feedback and keep learning from the streaming series!